### PR TITLE
Verantwoordelijkheid voor informatiebeveiliging

### DIFF
--- a/3_dk_architectuurprincipes.md
+++ b/3_dk_architectuurprincipes.md
@@ -26,7 +26,7 @@ De architectuurprincipes geven richting aan de Digikoppeling-standaarden en Digi
 
 2. **Standaardoplossingen:** Het gebruik van standaardoplossingen is mogelijk, met een minimum aan ontwikkelinspanning of maatwerk.
 
-3. **Veiligheid en vertrouwelijkheid:** Gegevens worden veilig uitgewisseld conform de eisen van de toepasselijke wet en regelgeving. Wanneer berichten met persoonsgegevens verstuurd worden, moet de serviceafnemer nagaan of de uitwisseling voldoet aan de wet- en regelgeving (in het bijzonder de AVG ).
+3. **Veiligheid en vertrouwelijkheid:** Gegevens worden veilig uitgewisseld conform de eisen van de toepasselijke wet en regelgeving. Wanneer berichten met persoonsgegevens verstuurd worden, moeten serviceaanbieder en serviceafnemer nagaan of de uitwisseling voldoet aan de wet- en regelgeving (in het bijzonder de AVG).
 
 4. **Betrouwbaarheid:**  Berichtaflevering is betrouwbaar indien nodig.
 


### PR DESCRIPTION
[Dit voorstel komt voort uit de vragen in #2]

# Aanleiding
Uitgangspunt 4 luidt:

Providers, zoals Basisregistraties en landelijke voorzieningen, bepalen welke koppelvlakstandaard gebruikt wordt voor een door hun geleverde dienst. Per dienst kunnen meerdere koppelvlakstandaarden aangeboden worden’.

Principe 3 luidt: (…)

Wanneer berichten met persoonsgegevens verstuurd worden, moet de serviceafnemer nagaan of de uitwisseling voldoet aan de wet- en regelgeving (in het bijzonder de AVG ).

Dit kan wel lastig worden. Overheidsdiensten zijn namelijk in bepaalde situaties verplicht om gegevens uit basisregisters op te halen (en niet zelf te vragen aan de burger of het bedrijf). De aanbieder bepaalt dan wat hij aanbiedt, maar de afnemer moet nagaan of dat voldoet aan de AVG. Wat te doen als het niet voldoet?
Zou er ook een verplichting moeten zijn aan de kant van de aanbieder?


# Voorstel

Principe 3

**Wanneer berichten met persoonsgegevens verstuurd worden, moeten serviceaanbieder en serviceafnemer nagaan of de uitwisseling voldoet aan de wet- en regelgeving (in het bijzonder de AVG ).**